### PR TITLE
adding first_letter and custom answer formatters

### DIFF
--- a/sae_spelling/prompting.py
+++ b/sae_spelling/prompting.py
@@ -1,4 +1,7 @@
+import random
 from dataclasses import dataclass
+from functools import partial
+from typing import Callable
 
 
 @dataclass
@@ -19,34 +22,78 @@ class SpellingPrompt:
     word: str
 
 
-def spelling(word: str, separator: str = "-", prefix: str = " ") -> str:
+def spelling(
+    word: str, separator: str = "-", prefix: str = " ", capitalize: bool = False
+) -> str:
     """
     Break a word string into its component characters, separated by `char_separator`
     e.g. spelling("cat") -> " c-a-t"
     """
-    return prefix + separator.join(list(word))
+    chars = list(word)
+    if capitalize:
+        chars = [c.upper() for c in chars]
+    return prefix + separator.join(chars)
+
+
+def first_letter(word: str, prefix: str = " ", capitalize: bool = False) -> str:
+    """
+    return just the first letter of the word, optionally capitalized
+    e.g. first_letter("cat") -> " c"
+    """
+    first_char = word[0]
+    if capitalize:
+        first_char = first_char.upper()
+    return prefix + first_char
+
+
+Formatter = Callable[[str], str]
+
+
+def spelling_formatter(
+    separator: str = "-", prefix: str = " ", capitalize: bool = False
+) -> Formatter:
+    return partial(spelling, separator=separator, prefix=prefix, capitalize=capitalize)
+
+
+def first_letter_formatter(prefix: str = " ", capitalize: bool = False) -> Formatter:
+    return partial(first_letter, prefix=prefix, capitalize=capitalize)
 
 
 def create_icl_prompt(
     word: str,
     examples: list[str],
     base_template: str = "{word}:",
-    char_separator: str = "-",
-    spelling_prefix: str = " ",
     example_separator: str = "\n",
+    answer_formatter: Formatter = spelling_formatter(),
+    max_icl_examples: int | None = None,
+    shuffle_examples: bool = True,
 ) -> SpellingPrompt:
     """
     Create a prompt with ICL examples in the base
+
+    Args:
+        word: the word to be spelled
+        examples: a list of examples to use as ICL prompts. These will be shuffled
+        base_template: a string template for the base of the prompt, including "{word}" as a placeholder for the word
+        example_separator: a string to use to separate the ICL examples. default is newline
+        answer_formatter: a function to format the answer. default is `spelling_formatter`, which spits out a string like " c-a-t" for the word "cat"
+        max_icl_examples: the maximum number of ICL examples to use. If None, all examples will be used. default is None
+        shuffle_examples: whether to shuffle the examples before selecting the first `max_icl_examples`. default is True
     """
     icl_prompts = []
-    for ex in examples:
-        ex_spelling = spelling(ex, separator=char_separator, prefix=spelling_prefix)
+    icl_examples = examples.copy()
+    if shuffle_examples:
+        random.shuffle(icl_examples)
+    if max_icl_examples is not None:
+        icl_examples = icl_examples[:max_icl_examples]
+    for ex in icl_examples:
+        ex_answer = answer_formatter(ex)
         ex_base = base_template.format(word=ex)
-        icl_prompts.append(ex_base + ex_spelling)
-    word_spelling = spelling(word, char_separator)
+        icl_prompts.append(ex_base + ex_answer)
+    word_answer = answer_formatter(word)
     word_base = base_template.format(word=word)
     return SpellingPrompt(
         base=example_separator.join(icl_prompts) + example_separator + word_base,
-        answer=word_spelling,
+        answer=word_answer,
         word=word,
     )

--- a/sae_spelling/spelling_grader.py
+++ b/sae_spelling/spelling_grader.py
@@ -1,4 +1,3 @@
-import random
 from dataclasses import dataclass
 from typing import cast
 
@@ -6,7 +5,12 @@ import torch
 from tqdm import tqdm
 from transformer_lens import HookedTransformer
 
-from sae_spelling.prompting import SpellingPrompt, create_icl_prompt
+from sae_spelling.prompting import (
+    Formatter,
+    SpellingPrompt,
+    create_icl_prompt,
+    spelling_formatter,
+)
 from sae_spelling.util import batchify
 
 
@@ -24,10 +28,9 @@ class SpellingGrade:
 class SpellingGrader:
     model: HookedTransformer
     icl_word_list: list[str]
-    n_icl_examples: int = 4
+    max_icl_examples: int | None = None
     base_template: str = "{word}:"
-    char_separator: str = "-"
-    spelling_prefix: str = " "
+    answer_formatter: Formatter = spelling_formatter()
     example_separator: str = "\n"
 
     def grade_word(self, word: str) -> SpellingGrade:
@@ -37,11 +40,11 @@ class SpellingGrader:
         prompts = [
             create_icl_prompt(
                 word,
-                random.sample(self.icl_word_list, self.n_icl_examples),
+                examples=self.icl_word_list,
                 base_template=self.base_template,
-                char_separator=self.char_separator,
-                spelling_prefix=self.spelling_prefix,
+                answer_formatter=spelling_formatter(),
                 example_separator=self.example_separator,
+                max_icl_examples=self.max_icl_examples,
             )
             for word in words
         ]

--- a/tests/test_prompting.py
+++ b/tests/test_prompting.py
@@ -1,6 +1,11 @@
 from textwrap import dedent
 
-from sae_spelling.prompting import create_icl_prompt, spelling
+from sae_spelling.prompting import (
+    create_icl_prompt,
+    first_letter,
+    first_letter_formatter,
+    spelling,
+)
 
 
 def test_spelling_uses_dash_as_default_separator():
@@ -11,12 +16,59 @@ def test_spelling_can_use_a_custom_separator():
     assert spelling("cat", separator=" :: ") == " c :: a :: t"
 
 
-def test_create_icl_prompt_with_default_separators():
-    prompt = create_icl_prompt("cat", examples=["dog", "bird"])
+def test_spelling_can_capitalize_letter():
+    assert spelling("cat", capitalize=True) == " C-A-T"
+
+
+def test_first_letter_selects_the_first_letter():
+    assert first_letter("cat") == " c"
+
+
+def test_first_letter_can_capitalize_letter():
+    assert first_letter("cat", capitalize=True) == " C"
+
+
+def test_create_icl_prompt_with_defaults():
+    prompt = create_icl_prompt("cat", examples=["dog", "bird"], shuffle_examples=False)
 
     expected_base = """
         dog: d-o-g
         bird: b-i-r-d
+        cat:
+    """
+    assert prompt.base == dedent(expected_base).strip()
+    assert prompt.word == "cat"
+    assert prompt.answer == " c-a-t"
+
+
+def test_create_icl_prompt_with_custom_answer_formatter():
+    prompt = create_icl_prompt(
+        "cat",
+        examples=["dog", "bird"],
+        shuffle_examples=False,
+        answer_formatter=first_letter_formatter(capitalize=True),
+    )
+
+    expected_base = """
+        dog: D
+        bird: B
+        cat:
+    """
+    assert prompt.base == dedent(expected_base).strip()
+    assert prompt.word == "cat"
+    assert prompt.answer == " C"
+
+
+def test_create_icl_prompt_can_specify_max_icl_examples():
+    prompt = create_icl_prompt(
+        "cat",
+        examples=["dog", "bird", "rat", "face"],
+        shuffle_examples=False,
+        max_icl_examples=1,
+    )
+
+    expected_base = """
+        dog: d-o-g
         cat:
     """
     assert prompt.base == dedent(expected_base).strip()

--- a/tests/test_spelling_grader.py
+++ b/tests/test_spelling_grader.py
@@ -26,7 +26,7 @@ def test_spelling_grader_marks_response_wrong_if_model_predicts_incorrectly(
     gpt2_model: HookedTransformer,
 ):
     # GPT2 is terrible at spelling and will get the following wrong
-    grader = SpellingGrader(gpt2_model, icl_word_list=["bananas"], n_icl_examples=1)
+    grader = SpellingGrader(gpt2_model, icl_word_list=["bananas"], max_icl_examples=1)
     grade = grader.grade_word("incorrect")
     assert grade.is_correct is False
     assert grade.answer == " i-n-c-o-r-r-e-c-t"
@@ -37,7 +37,7 @@ def test_spelling_grader_marks_response_wrong_if_model_predicts_incorrectly(
 def test_spelling_grader_batch_processing_gives_the_same_results_as_individual_processing(
     gpt2_model: HookedTransformer,
 ):
-    grader = SpellingGrader(gpt2_model, icl_word_list=["bananas"], n_icl_examples=1)
+    grader = SpellingGrader(gpt2_model, icl_word_list=["bananas"], max_icl_examples=1)
     words = ["hotdog", "bananas", "spaceship"]
     batch_grades = grader.grade_words(words, batch_size=len(words))
     individual_grades = [grader.grade_word(word) for word in words]


### PR DESCRIPTION
This PR is a follow-up from #1, implementing the following:
- the `create_icl_prompts()` function takes in an `answer_formatter` param, which is a callable that returns a string. This allows us to format the answers any way we want, like just selecting the first letter of the word.
- the `create_icl_prompts()` function takes in a `max_icl_examples` param, which can be used to cap the number of examples from the example list if we want to pass in a large diction of possible ICL prompts and have them be selected at random.
- adds a `first_letter()` function to select the first letter of a given word
- adds `capitalize` options to both `first_letter()` and `spelling()` functions, default false
- adds `spelling_formatter()` and `first_letter_formatter()` helpers to easily turn the `spelling()` and `first_letter()` functions into answer formatters for use in the `create_icl_prompts()` function.