### PR TITLE
improving prompting helpers for spacing and perf

### DIFF
--- a/sae_spelling/prompting.py
+++ b/sae_spelling/prompting.py
@@ -23,24 +23,44 @@ class SpellingPrompt:
 
 
 def spelling(
-    word: str, separator: str = "-", prefix: str = " ", capitalize: bool = False
+    word: str,
+    separator: str = "-",
+    prefix: str = " ",
+    capitalize: bool = False,
+    ignore_leading_space: bool = True,
+    ignore_non_alpha_chars: bool = True,
 ) -> str:
     """
     Break a word string into its component characters, separated by `char_separator`
     e.g. spelling("cat") -> " c-a-t"
     """
+    if ignore_leading_space:
+        word = word.strip()
     chars = list(word)
+    if ignore_non_alpha_chars:
+        chars = [c for c in chars if c.isalpha()]
     if capitalize:
         chars = [c.upper() for c in chars]
     return prefix + separator.join(chars)
 
 
-def first_letter(word: str, prefix: str = " ", capitalize: bool = False) -> str:
+def first_letter(
+    word: str,
+    prefix: str = " ",
+    capitalize: bool = False,
+    ignore_leading_space: bool = True,
+    ignore_non_alpha_chars: bool = True,
+) -> str:
     """
     return just the first letter of the word, optionally capitalized
     e.g. first_letter("cat") -> " c"
     """
-    first_char = word[0]
+    if ignore_leading_space:
+        word = word.strip()
+    chars = list(word)
+    if ignore_non_alpha_chars:
+        chars = [c for c in chars if c.isalpha()]
+    first_char = chars[0]
     if capitalize:
         first_char = first_char.upper()
     return prefix + first_char
@@ -50,13 +70,35 @@ Formatter = Callable[[str], str]
 
 
 def spelling_formatter(
-    separator: str = "-", prefix: str = " ", capitalize: bool = False
+    separator: str = "-",
+    prefix: str = " ",
+    capitalize: bool = False,
+    ignore_leading_space: bool = True,
+    ignore_non_alpha_chars: bool = True,
 ) -> Formatter:
-    return partial(spelling, separator=separator, prefix=prefix, capitalize=capitalize)
+    return partial(
+        spelling,
+        separator=separator,
+        prefix=prefix,
+        capitalize=capitalize,
+        ignore_leading_space=ignore_leading_space,
+        ignore_non_alpha_chars=ignore_non_alpha_chars,
+    )
 
 
-def first_letter_formatter(prefix: str = " ", capitalize: bool = False) -> Formatter:
-    return partial(first_letter, prefix=prefix, capitalize=capitalize)
+def first_letter_formatter(
+    prefix: str = " ",
+    capitalize: bool = False,
+    ignore_leading_space: bool = True,
+    ignore_non_alpha_chars: bool = True,
+) -> Formatter:
+    return partial(
+        first_letter,
+        prefix=prefix,
+        capitalize=capitalize,
+        ignore_leading_space=ignore_leading_space,
+        ignore_non_alpha_chars=ignore_non_alpha_chars,
+    )
 
 
 def create_icl_prompt(
@@ -82,10 +124,14 @@ def create_icl_prompt(
     """
     icl_prompts = []
     icl_examples = examples.copy()
-    if shuffle_examples:
-        random.shuffle(icl_examples)
+
     if max_icl_examples is not None:
-        icl_examples = icl_examples[:max_icl_examples]
+        if shuffle_examples:
+            icl_examples = random.sample(icl_examples, max_icl_examples)
+        else:
+            icl_examples = icl_examples[:max_icl_examples]
+    elif shuffle_examples:
+        random.shuffle(icl_examples)
     for ex in icl_examples:
         ex_answer = answer_formatter(ex)
         ex_base = base_template.format(word=ex)

--- a/tests/test_prompting.py
+++ b/tests/test_prompting.py
@@ -12,6 +12,19 @@ def test_spelling_uses_dash_as_default_separator():
     assert spelling("cat") == " c-a-t"
 
 
+def test_spelling_ignores_non_alphanum_chars_and_leading_space_by_default():
+    assert spelling("_cat") == " c-a-t"
+    assert spelling(" cat") == " c-a-t"
+    assert spelling("▁cat") == " c-a-t"
+    assert spelling("1cat") == " c-a-t"
+
+
+def test_spelling_can_respect_non_alphanum_chars():
+    assert spelling(" cat", ignore_non_alpha_chars=False) == " c-a-t"
+    assert spelling("▁cat", ignore_non_alpha_chars=False) == " ▁-c-a-t"
+    assert spelling("1cat", ignore_non_alpha_chars=False) == " 1-c-a-t"
+
+
 def test_spelling_can_use_a_custom_separator():
     assert spelling("cat", separator=" :: ") == " c :: a :: t"
 
@@ -26,6 +39,20 @@ def test_first_letter_selects_the_first_letter():
 
 def test_first_letter_can_capitalize_letter():
     assert first_letter("cat", capitalize=True) == " C"
+
+
+def test_first_letter_ignores_non_alphanum_chars_and_leading_space_by_default():
+    assert first_letter("_cat") == " c"
+    assert first_letter(" cat") == " c"
+    assert first_letter(" CAT") == " C"
+    assert first_letter("▁cat") == " c"
+    assert first_letter("1cat") == " c"
+
+
+def test_first_letter_can_respect_non_alphanum_chars():
+    assert first_letter(" cat", ignore_non_alpha_chars=False) == " c"
+    assert first_letter("▁cat", ignore_non_alpha_chars=False) == " ▁"
+    assert first_letter("1cat", ignore_non_alpha_chars=False) == " 1"
 
 
 def test_create_icl_prompt_with_defaults():


### PR DESCRIPTION
This PR adds some prompting improvements from pairing with @TDulka. Specifically:

- `create_icl_prompt` using `random.sample` instead of `shuffle` for picking ICL examples. This should be a large performance improvement when we provide a large vocab size.
- `spelling` and `first_letter` helpers now ignore non-alpha chars by default, but this can be configured if so desired.