### PR TITLE
Gradient-based feature attribution

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -164,6 +164,35 @@ test = ["anyio[trio]", "coverage[toml] (>=7)", "exceptiongroup (>=1.2.0)", "hypo
 trio = ["trio (>=0.23)"]
 
 [[package]]
+name = "appnope"
+version = "0.1.4"
+description = "Disable App Nap on macOS >= 10.9"
+optional = false
+python-versions = ">=3.6"
+files = [
+    {file = "appnope-0.1.4-py2.py3-none-any.whl", hash = "sha256:502575ee11cd7a28c0205f379b525beefebab9d161b7c964670864014ed7213c"},
+    {file = "appnope-0.1.4.tar.gz", hash = "sha256:1de3860566df9caf38f01f86f65e0e13e379af54f9e4bee1e66b48f2efffd1ee"},
+]
+
+[[package]]
+name = "asttokens"
+version = "2.4.1"
+description = "Annotate AST trees with source code positions"
+optional = false
+python-versions = "*"
+files = [
+    {file = "asttokens-2.4.1-py2.py3-none-any.whl", hash = "sha256:051ed49c3dcae8913ea7cd08e46a606dba30b79993209636c4875bc1d637bc24"},
+    {file = "asttokens-2.4.1.tar.gz", hash = "sha256:b03869718ba9a6eb027e134bfdf69f38a236d681c83c160d510768af11254ba0"},
+]
+
+[package.dependencies]
+six = ">=1.12.0"
+
+[package.extras]
+astroid = ["astroid (>=1,<2)", "astroid (>=2,<4)"]
+test = ["astroid (>=1,<2)", "astroid (>=2,<4)", "pytest"]
+
+[[package]]
 name = "async-timeout"
 version = "4.0.3"
 description = "Timeout context manager for asyncio programs"
@@ -504,14 +533,31 @@ files = [
 ]
 
 [[package]]
+name = "comm"
+version = "0.2.2"
+description = "Jupyter Python Comm implementation, for usage in ipykernel, xeus-python etc."
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "comm-0.2.2-py3-none-any.whl", hash = "sha256:e6fb86cb70ff661ee8c9c14e7d36d6de3b4066f1441be4063df9c5009f0a64d3"},
+    {file = "comm-0.2.2.tar.gz", hash = "sha256:3fd7a84065306e07bea1773df6eb8282de51ba82f77c72f9c85716ab11fe980e"},
+]
+
+[package.dependencies]
+traitlets = ">=4"
+
+[package.extras]
+test = ["pytest"]
+
+[[package]]
 name = "config2py"
-version = "0.1.33"
+version = "0.1.34"
 description = "Simplified reading and writing configurations from various sources and formats"
 optional = false
 python-versions = "*"
 files = [
-    {file = "config2py-0.1.33-py3-none-any.whl", hash = "sha256:538dce5738d2d41711da086d194928cc8566457b82679c2199c7456e3fdc191c"},
-    {file = "config2py-0.1.33.tar.gz", hash = "sha256:9d0a355f1eb61534248daa677d4db0380f3f471d99633bccc1ef8fac879dfaef"},
+    {file = "config2py-0.1.34-py3-none-any.whl", hash = "sha256:9adb1587fdc4272adf818306474e6bd0455c8ecc11c118d9376a2c3e21761e9e"},
+    {file = "config2py-0.1.34.tar.gz", hash = "sha256:79058e374b8e9b17db241b7ee2d4c9300c3cd5e2e9f9ffb723c50597b2fb8454"},
 ]
 
 [package.dependencies]
@@ -597,21 +643,6 @@ docs = ["ipython", "matplotlib", "numpydoc", "sphinx"]
 tests = ["pytest", "pytest-cov", "pytest-xdist"]
 
 [[package]]
-name = "dataclasses-json"
-version = "0.6.7"
-description = "Easily serialize dataclasses to and from JSON."
-optional = false
-python-versions = "<4.0,>=3.7"
-files = [
-    {file = "dataclasses_json-0.6.7-py3-none-any.whl", hash = "sha256:0dbf33f26c8d5305befd61b39d2b3414e8a407bedc2834dea9b8d642666fb40a"},
-    {file = "dataclasses_json-0.6.7.tar.gz", hash = "sha256:b6b3e528266ea45b9535223bc53ca645f5208833c29229e847b3f26a1cc55fc0"},
-]
-
-[package.dependencies]
-marshmallow = ">=3.18.0,<4.0.0"
-typing-inspect = ">=0.4.0,<1"
-
-[[package]]
 name = "datasets"
 version = "2.20.0"
 description = "HuggingFace community-driven open-source library of datasets"
@@ -654,6 +685,48 @@ tensorflow-gpu = ["tensorflow (>=2.6.0)"]
 tests = ["Pillow (>=9.4.0)", "absl-py", "elasticsearch (<8.0.0)", "faiss-cpu (>=1.6.4)", "jax (>=0.3.14)", "jaxlib (>=0.3.14)", "joblib (<1.3.0)", "joblibspark", "librosa", "lz4", "polars[timezone] (>=0.20.0)", "protobuf (<4.0.0)", "py7zr", "pyspark (>=3.4)", "pytest", "pytest-datadir", "pytest-xdist", "rarfile (>=4.0)", "s3fs (>=2021.11.1)", "soundfile (>=0.12.1)", "sqlalchemy", "tensorflow (>=2.6.0)", "tiktoken", "torch (>=2.0.0)", "transformers", "typing-extensions (>=4.6.1)", "zstandard"]
 torch = ["torch"]
 vision = ["Pillow (>=9.4.0)"]
+
+[[package]]
+name = "debugpy"
+version = "1.8.2"
+description = "An implementation of the Debug Adapter Protocol for Python"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "debugpy-1.8.2-cp310-cp310-macosx_11_0_x86_64.whl", hash = "sha256:7ee2e1afbf44b138c005e4380097d92532e1001580853a7cb40ed84e0ef1c3d2"},
+    {file = "debugpy-1.8.2-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3f8c3f7c53130a070f0fc845a0f2cee8ed88d220d6b04595897b66605df1edd6"},
+    {file = "debugpy-1.8.2-cp310-cp310-win32.whl", hash = "sha256:f179af1e1bd4c88b0b9f0fa153569b24f6b6f3de33f94703336363ae62f4bf47"},
+    {file = "debugpy-1.8.2-cp310-cp310-win_amd64.whl", hash = "sha256:0600faef1d0b8d0e85c816b8bb0cb90ed94fc611f308d5fde28cb8b3d2ff0fe3"},
+    {file = "debugpy-1.8.2-cp311-cp311-macosx_11_0_universal2.whl", hash = "sha256:8a13417ccd5978a642e91fb79b871baded925d4fadd4dfafec1928196292aa0a"},
+    {file = "debugpy-1.8.2-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:acdf39855f65c48ac9667b2801234fc64d46778021efac2de7e50907ab90c634"},
+    {file = "debugpy-1.8.2-cp311-cp311-win32.whl", hash = "sha256:2cbd4d9a2fc5e7f583ff9bf11f3b7d78dfda8401e8bb6856ad1ed190be4281ad"},
+    {file = "debugpy-1.8.2-cp311-cp311-win_amd64.whl", hash = "sha256:d3408fddd76414034c02880e891ea434e9a9cf3a69842098ef92f6e809d09afa"},
+    {file = "debugpy-1.8.2-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:5d3ccd39e4021f2eb86b8d748a96c766058b39443c1f18b2dc52c10ac2757835"},
+    {file = "debugpy-1.8.2-cp312-cp312-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:62658aefe289598680193ff655ff3940e2a601765259b123dc7f89c0239b8cd3"},
+    {file = "debugpy-1.8.2-cp312-cp312-win32.whl", hash = "sha256:bd11fe35d6fd3431f1546d94121322c0ac572e1bfb1f6be0e9b8655fb4ea941e"},
+    {file = "debugpy-1.8.2-cp312-cp312-win_amd64.whl", hash = "sha256:15bc2f4b0f5e99bf86c162c91a74c0631dbd9cef3c6a1d1329c946586255e859"},
+    {file = "debugpy-1.8.2-cp38-cp38-macosx_11_0_x86_64.whl", hash = "sha256:5a019d4574afedc6ead1daa22736c530712465c0c4cd44f820d803d937531b2d"},
+    {file = "debugpy-1.8.2-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:40f062d6877d2e45b112c0bbade9a17aac507445fd638922b1a5434df34aed02"},
+    {file = "debugpy-1.8.2-cp38-cp38-win32.whl", hash = "sha256:c78ba1680f1015c0ca7115671fe347b28b446081dada3fedf54138f44e4ba031"},
+    {file = "debugpy-1.8.2-cp38-cp38-win_amd64.whl", hash = "sha256:cf327316ae0c0e7dd81eb92d24ba8b5e88bb4d1b585b5c0d32929274a66a5210"},
+    {file = "debugpy-1.8.2-cp39-cp39-macosx_11_0_x86_64.whl", hash = "sha256:1523bc551e28e15147815d1397afc150ac99dbd3a8e64641d53425dba57b0ff9"},
+    {file = "debugpy-1.8.2-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e24ccb0cd6f8bfaec68d577cb49e9c680621c336f347479b3fce060ba7c09ec1"},
+    {file = "debugpy-1.8.2-cp39-cp39-win32.whl", hash = "sha256:7f8d57a98c5a486c5c7824bc0b9f2f11189d08d73635c326abef268f83950326"},
+    {file = "debugpy-1.8.2-cp39-cp39-win_amd64.whl", hash = "sha256:16c8dcab02617b75697a0a925a62943e26a0330da076e2a10437edd9f0bf3755"},
+    {file = "debugpy-1.8.2-py2.py3-none-any.whl", hash = "sha256:16e16df3a98a35c63c3ab1e4d19be4cbc7fdda92d9ddc059294f18910928e0ca"},
+    {file = "debugpy-1.8.2.zip", hash = "sha256:95378ed08ed2089221896b9b3a8d021e642c24edc8fef20e5d4342ca8be65c00"},
+]
+
+[[package]]
+name = "decorator"
+version = "5.1.1"
+description = "Decorators for Humans"
+optional = false
+python-versions = ">=3.5"
+files = [
+    {file = "decorator-5.1.1-py3-none-any.whl", hash = "sha256:b8c3f85900b9dc423225913c5aace94729fe1fa9763b38939a95226f02d37186"},
+    {file = "decorator-5.1.1.tar.gz", hash = "sha256:637996211036b6385ef91435e4fae22989472f9d571faba8927ba8253acbc330"},
+]
 
 [[package]]
 name = "dill"
@@ -707,21 +780,6 @@ files = [
 ]
 
 [[package]]
-name = "eindex-callum"
-version = "0.1.1"
-description = "My interpretation of einops-like indexing"
-optional = false
-python-versions = "*"
-files = [
-    {file = "eindex-callum-0.1.1.tar.gz", hash = "sha256:4de6ef13647f9d60a7c4425440fbc2e29af098ddd2038bcd229a2c1947c80121"},
-    {file = "eindex_callum-0.1.1-py3-none-any.whl", hash = "sha256:f819f82c46b6f0fc85333b6af08da8467137c7bea5477fcfa47586ebcc258a2d"},
-]
-
-[package.dependencies]
-einops = "*"
-torch = "*"
-
-[[package]]
 name = "einops"
 version = "0.7.0"
 description = "A new flavour of deep learning operations"
@@ -745,6 +803,20 @@ files = [
 
 [package.extras]
 test = ["pytest (>=6)"]
+
+[[package]]
+name = "executing"
+version = "2.0.1"
+description = "Get the currently executing AST node of a frame, and other information"
+optional = false
+python-versions = ">=3.5"
+files = [
+    {file = "executing-2.0.1-py2.py3-none-any.whl", hash = "sha256:eac49ca94516ccc753f9fb5ce82603156e590b27525a8bc32cce8ae302eb61bc"},
+    {file = "executing-2.0.1.tar.gz", hash = "sha256:35afe2ce3affba8ee97f2d69927fa823b08b472b7b994e36a52a964b93d16147"},
+]
+
+[package.extras]
+tests = ["asttokens (>=2.1.0)", "coverage", "coverage-enable-subprocess", "ipython", "littleutils", "pytest", "rich"]
 
 [[package]]
 name = "fancy-einsum"
@@ -1190,18 +1262,108 @@ files = [
 ]
 
 [[package]]
+name = "ipykernel"
+version = "6.29.5"
+description = "IPython Kernel for Jupyter"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "ipykernel-6.29.5-py3-none-any.whl", hash = "sha256:afdb66ba5aa354b09b91379bac28ae4afebbb30e8b39510c9690afb7a10421b5"},
+    {file = "ipykernel-6.29.5.tar.gz", hash = "sha256:f093a22c4a40f8828f8e330a9c297cb93dcab13bd9678ded6de8e5cf81c56215"},
+]
+
+[package.dependencies]
+appnope = {version = "*", markers = "platform_system == \"Darwin\""}
+comm = ">=0.1.1"
+debugpy = ">=1.6.5"
+ipython = ">=7.23.1"
+jupyter-client = ">=6.1.12"
+jupyter-core = ">=4.12,<5.0.dev0 || >=5.1.dev0"
+matplotlib-inline = ">=0.1"
+nest-asyncio = "*"
+packaging = "*"
+psutil = "*"
+pyzmq = ">=24"
+tornado = ">=6.1"
+traitlets = ">=5.4.0"
+
+[package.extras]
+cov = ["coverage[toml]", "curio", "matplotlib", "pytest-cov", "trio"]
+docs = ["myst-parser", "pydata-sphinx-theme", "sphinx", "sphinx-autodoc-typehints", "sphinxcontrib-github-alt", "sphinxcontrib-spelling", "trio"]
+pyqt5 = ["pyqt5"]
+pyside6 = ["pyside6"]
+test = ["flaky", "ipyparallel", "pre-commit", "pytest (>=7.0)", "pytest-asyncio (>=0.23.5)", "pytest-cov", "pytest-timeout"]
+
+[[package]]
+name = "ipython"
+version = "8.26.0"
+description = "IPython: Productive Interactive Computing"
+optional = false
+python-versions = ">=3.10"
+files = [
+    {file = "ipython-8.26.0-py3-none-any.whl", hash = "sha256:e6b347c27bdf9c32ee9d31ae85defc525755a1869f14057e900675b9e8d6e6ff"},
+    {file = "ipython-8.26.0.tar.gz", hash = "sha256:1cec0fbba8404af13facebe83d04436a7434c7400e59f47acf467c64abd0956c"},
+]
+
+[package.dependencies]
+colorama = {version = "*", markers = "sys_platform == \"win32\""}
+decorator = "*"
+exceptiongroup = {version = "*", markers = "python_version < \"3.11\""}
+jedi = ">=0.16"
+matplotlib-inline = "*"
+pexpect = {version = ">4.3", markers = "sys_platform != \"win32\" and sys_platform != \"emscripten\""}
+prompt-toolkit = ">=3.0.41,<3.1.0"
+pygments = ">=2.4.0"
+stack-data = "*"
+traitlets = ">=5.13.0"
+typing-extensions = {version = ">=4.6", markers = "python_version < \"3.12\""}
+
+[package.extras]
+all = ["ipython[black,doc,kernel,matplotlib,nbconvert,nbformat,notebook,parallel,qtconsole]", "ipython[test,test-extra]"]
+black = ["black"]
+doc = ["docrepr", "exceptiongroup", "intersphinx-registry", "ipykernel", "ipython[test]", "matplotlib", "setuptools (>=18.5)", "sphinx (>=1.3)", "sphinx-rtd-theme", "sphinxcontrib-jquery", "tomli", "typing-extensions"]
+kernel = ["ipykernel"]
+matplotlib = ["matplotlib"]
+nbconvert = ["nbconvert"]
+nbformat = ["nbformat"]
+notebook = ["ipywidgets", "notebook"]
+parallel = ["ipyparallel"]
+qtconsole = ["qtconsole"]
+test = ["packaging", "pickleshare", "pytest", "pytest-asyncio (<0.22)", "testpath"]
+test-extra = ["curio", "ipython[test]", "matplotlib (!=3.2.0)", "nbformat", "numpy (>=1.23)", "pandas", "trio"]
+
+[[package]]
 name = "jaxtyping"
-version = "0.2.31"
+version = "0.2.33"
 description = "Type annotations and runtime checking for shape and dtype of JAX arrays, and PyTrees."
 optional = false
 python-versions = "~=3.9"
 files = [
-    {file = "jaxtyping-0.2.31-py3-none-any.whl", hash = "sha256:04ed0e16ad4327270c8832334aa5d06176f475f3f8bdf7200bebc54afb1e3fd3"},
-    {file = "jaxtyping-0.2.31.tar.gz", hash = "sha256:83c7c0bfae1d1ce25801480b5572d96c0f2b889785b4e50bdc25a07058b7bd50"},
+    {file = "jaxtyping-0.2.33-py3-none-any.whl", hash = "sha256:918d6094c73f28d3196185ef55d1832cbcd2804d1d388f180060c4366a9e2107"},
+    {file = "jaxtyping-0.2.33.tar.gz", hash = "sha256:9a9cfccae4fe05114b9fb27a5ea5440be4971a5a075bbd0526f6dd7d2730f83e"},
 ]
 
 [package.dependencies]
 typeguard = "2.13.3"
+
+[[package]]
+name = "jedi"
+version = "0.19.1"
+description = "An autocompletion tool for Python that can be used for text editors."
+optional = false
+python-versions = ">=3.6"
+files = [
+    {file = "jedi-0.19.1-py2.py3-none-any.whl", hash = "sha256:e983c654fe5c02867aef4cdfce5a2fbb4a50adc0af145f70504238f18ef5e7e0"},
+    {file = "jedi-0.19.1.tar.gz", hash = "sha256:cf0496f3651bc65d7174ac1b7d043eff454892c708a87d1b683e57b569927ffd"},
+]
+
+[package.dependencies]
+parso = ">=0.8.3,<0.9.0"
+
+[package.extras]
+docs = ["Jinja2 (==2.11.3)", "MarkupSafe (==1.1.1)", "Pygments (==2.8.1)", "alabaster (==0.7.12)", "babel (==2.9.1)", "chardet (==4.0.0)", "commonmark (==0.8.1)", "docutils (==0.17.1)", "future (==0.18.2)", "idna (==2.10)", "imagesize (==1.2.0)", "mock (==1.0.1)", "packaging (==20.9)", "pyparsing (==2.4.7)", "pytz (==2021.1)", "readthedocs-sphinx-ext (==2.1.4)", "recommonmark (==0.5.0)", "requests (==2.25.1)", "six (==1.15.0)", "snowballstemmer (==2.1.0)", "sphinx (==1.8.5)", "sphinx-rtd-theme (==0.4.3)", "sphinxcontrib-serializinghtml (==1.1.4)", "sphinxcontrib-websupport (==1.2.4)", "urllib3 (==1.26.4)"]
+qa = ["flake8 (==5.0.4)", "mypy (==0.971)", "types-setuptools (==67.2.0.1)"]
+testing = ["Django", "attrs", "colorama", "docopt", "pytest (<7.0.0)"]
 
 [[package]]
 name = "jinja2"
@@ -1230,6 +1392,48 @@ files = [
     {file = "joblib-1.4.2-py3-none-any.whl", hash = "sha256:06d478d5674cbc267e7496a410ee875abd68e4340feff4490bcb7afb88060ae6"},
     {file = "joblib-1.4.2.tar.gz", hash = "sha256:2382c5816b2636fbd20a09e0f4e9dad4736765fdfb7dca582943b9c1366b3f0e"},
 ]
+
+[[package]]
+name = "jupyter-client"
+version = "8.6.2"
+description = "Jupyter protocol implementation and client libraries"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "jupyter_client-8.6.2-py3-none-any.whl", hash = "sha256:50cbc5c66fd1b8f65ecb66bc490ab73217993632809b6e505687de18e9dea39f"},
+    {file = "jupyter_client-8.6.2.tar.gz", hash = "sha256:2bda14d55ee5ba58552a8c53ae43d215ad9868853489213f37da060ced54d8df"},
+]
+
+[package.dependencies]
+jupyter-core = ">=4.12,<5.0.dev0 || >=5.1.dev0"
+python-dateutil = ">=2.8.2"
+pyzmq = ">=23.0"
+tornado = ">=6.2"
+traitlets = ">=5.3"
+
+[package.extras]
+docs = ["ipykernel", "myst-parser", "pydata-sphinx-theme", "sphinx (>=4)", "sphinx-autodoc-typehints", "sphinxcontrib-github-alt", "sphinxcontrib-spelling"]
+test = ["coverage", "ipykernel (>=6.14)", "mypy", "paramiko", "pre-commit", "pytest (<8.2.0)", "pytest-cov", "pytest-jupyter[client] (>=0.4.1)", "pytest-timeout"]
+
+[[package]]
+name = "jupyter-core"
+version = "5.7.2"
+description = "Jupyter core package. A base package on which Jupyter projects rely."
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "jupyter_core-5.7.2-py3-none-any.whl", hash = "sha256:4f7315d2f6b4bcf2e3e7cb6e46772eba760ae459cd1f59d29eb57b0a01bd7409"},
+    {file = "jupyter_core-5.7.2.tar.gz", hash = "sha256:aa5f8d32bbf6b431ac830496da7392035d6f61b4f54872f15c4bd2a9c3f536d9"},
+]
+
+[package.dependencies]
+platformdirs = ">=2.5"
+pywin32 = {version = ">=300", markers = "sys_platform == \"win32\" and platform_python_implementation != \"PyPy\""}
+traitlets = ">=5.3"
+
+[package.extras]
+docs = ["myst-parser", "pydata-sphinx-theme", "sphinx-autodoc-typehints", "sphinxcontrib-github-alt", "sphinxcontrib-spelling", "traitlets"]
+test = ["ipykernel", "pre-commit", "pytest (<8)", "pytest-cov", "pytest-timeout"]
 
 [[package]]
 name = "kiwisolver"
@@ -1546,25 +1750,6 @@ files = [
 ]
 
 [[package]]
-name = "marshmallow"
-version = "3.21.3"
-description = "A lightweight library for converting complex datatypes to and from native Python datatypes."
-optional = false
-python-versions = ">=3.8"
-files = [
-    {file = "marshmallow-3.21.3-py3-none-any.whl", hash = "sha256:86ce7fb914aa865001a4b2092c4c2872d13bc347f3d42673272cabfdbad386f1"},
-    {file = "marshmallow-3.21.3.tar.gz", hash = "sha256:4f57c5e050a54d66361e826f94fba213eb10b67b2fdb02c3e0343ce207ba1662"},
-]
-
-[package.dependencies]
-packaging = ">=17.0"
-
-[package.extras]
-dev = ["marshmallow[tests]", "pre-commit (>=3.5,<4.0)", "tox"]
-docs = ["alabaster (==0.7.16)", "autodocsumm (==0.2.12)", "sphinx (==7.3.7)", "sphinx-issues (==4.1.0)", "sphinx-version-warning (==1.1.2)"]
-tests = ["pytest", "pytz", "simplejson"]
-
-[[package]]
 name = "matplotlib"
 version = "3.9.1"
 description = "Python plotting package"
@@ -1800,14 +1985,14 @@ files = [
 dill = ">=0.3.8"
 
 [[package]]
-name = "mypy-extensions"
-version = "1.0.0"
-description = "Type system extensions for programs checked with the mypy type checker."
+name = "nest-asyncio"
+version = "1.6.0"
+description = "Patch asyncio to allow nested event loops"
 optional = false
 python-versions = ">=3.5"
 files = [
-    {file = "mypy_extensions-1.0.0-py3-none-any.whl", hash = "sha256:4392f6c0eb8a5668a69e23d168ffa70f0be9ccfd32b5cc2d26a34ae5b844552d"},
-    {file = "mypy_extensions-1.0.0.tar.gz", hash = "sha256:75dbf8955dc00442a438fc4d0666508a9a97b6bd41aa2f0ffe9d2f2725af0782"},
+    {file = "nest_asyncio-1.6.0-py3-none-any.whl", hash = "sha256:87af6efd6b5e897c81050477ef65c62e2b2f35d51703cae01aff2905b1852e1c"},
+    {file = "nest_asyncio-1.6.0.tar.gz", hash = "sha256:6f172d5449aca15afd6c646851f4e31e02c598d553a667e38cafa997cfec55fe"},
 ]
 
 [[package]]
@@ -2196,6 +2381,21 @@ test = ["hypothesis (>=6.46.1)", "pytest (>=7.3.2)", "pytest-xdist (>=2.2.0)"]
 xml = ["lxml (>=4.9.2)"]
 
 [[package]]
+name = "parso"
+version = "0.8.4"
+description = "A Python Parser"
+optional = false
+python-versions = ">=3.6"
+files = [
+    {file = "parso-0.8.4-py2.py3-none-any.whl", hash = "sha256:a418670a20291dacd2dddc80c377c5c3791378ee1e8d12bffc35420643d43f18"},
+    {file = "parso-0.8.4.tar.gz", hash = "sha256:eb3a7b58240fb99099a345571deecc0f9540ea5f4dd2fe14c2a99d6b281ab92d"},
+]
+
+[package.extras]
+qa = ["flake8 (==5.0.4)", "mypy (==0.971)", "types-setuptools (==67.2.0.1)"]
+testing = ["docopt", "pytest"]
+
+[[package]]
 name = "patsy"
 version = "0.5.6"
 description = "A Python package for describing statistical models and for building design matrices."
@@ -2212,6 +2412,20 @@ six = "*"
 
 [package.extras]
 test = ["pytest", "pytest-cov", "scipy"]
+
+[[package]]
+name = "pexpect"
+version = "4.9.0"
+description = "Pexpect allows easy control of interactive console applications."
+optional = false
+python-versions = "*"
+files = [
+    {file = "pexpect-4.9.0-py2.py3-none-any.whl", hash = "sha256:7236d1e080e4936be2dc3e326cec0af72acf9212a7e1d060210e70a47e253523"},
+    {file = "pexpect-4.9.0.tar.gz", hash = "sha256:ee7d41123f3c9911050ea2c2dac107568dc43b2d3b0c7557a33212c398ead30f"},
+]
+
+[package.dependencies]
+ptyprocess = ">=0.5"
 
 [[package]]
 name = "pillow"
@@ -2394,6 +2608,20 @@ pyyaml = ">=5.1"
 virtualenv = ">=20.10.0"
 
 [[package]]
+name = "prompt-toolkit"
+version = "3.0.47"
+description = "Library for building powerful interactive command lines in Python"
+optional = false
+python-versions = ">=3.7.0"
+files = [
+    {file = "prompt_toolkit-3.0.47-py3-none-any.whl", hash = "sha256:0d7bfa67001d5e39d02c224b663abc33687405033a8c422d0d675a5a13361d10"},
+    {file = "prompt_toolkit-3.0.47.tar.gz", hash = "sha256:1e1b29cb58080b1e69f207c893a1a7bf16d127a5c30c9d17a25a5d77792e5360"},
+]
+
+[package.dependencies]
+wcwidth = "*"
+
+[[package]]
 name = "protobuf"
 version = "5.27.2"
 description = ""
@@ -2441,6 +2669,31 @@ files = [
 
 [package.extras]
 test = ["enum34", "ipaddress", "mock", "pywin32", "wmi"]
+
+[[package]]
+name = "ptyprocess"
+version = "0.7.0"
+description = "Run a subprocess in a pseudo terminal"
+optional = false
+python-versions = "*"
+files = [
+    {file = "ptyprocess-0.7.0-py2.py3-none-any.whl", hash = "sha256:4b41f3967fce3af57cc7e94b888626c18bf37a083e3651ca8feeb66d492fef35"},
+    {file = "ptyprocess-0.7.0.tar.gz", hash = "sha256:5c5d0a3b48ceee0b48485e0c26037c0acd7d29765ca3fbb5cb3831d347423220"},
+]
+
+[[package]]
+name = "pure-eval"
+version = "0.2.2"
+description = "Safely evaluate AST nodes without side effects"
+optional = false
+python-versions = "*"
+files = [
+    {file = "pure_eval-0.2.2-py3-none-any.whl", hash = "sha256:01eaab343580944bc56080ebe0a674b39ec44a945e6d09ba7db3cb8cec289350"},
+    {file = "pure_eval-0.2.2.tar.gz", hash = "sha256:2b45320af6dfaa1750f543d714b6d1c520a1688dec6fd24d339063ce0aaa9ac3"},
+]
+
+[package.extras]
+tests = ["pytest"]
 
 [[package]]
 name = "py2store"
@@ -2601,13 +2854,13 @@ diagrams = ["jinja2", "railroad-diagrams"]
 
 [[package]]
 name = "pyright"
-version = "1.1.370"
+version = "1.1.371"
 description = "Command line wrapper for pyright"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "pyright-1.1.370-py3-none-any.whl", hash = "sha256:fc721601e480a69989775bfc210534a6ca0110ebd0c065244a8d3a151294fc61"},
-    {file = "pyright-1.1.370.tar.gz", hash = "sha256:d0d559d506fc41e3297f721aaa05a1b9f06beda5acc9ac64ca371ce94c28f960"},
+    {file = "pyright-1.1.371-py3-none-any.whl", hash = "sha256:cce52e42ff73943243e7e5e24f2a59dee81b97d99f4e3cf97370b27e8a1858cd"},
+    {file = "pyright-1.1.371.tar.gz", hash = "sha256:777b508b92dda2db476214c400ce043aad8d8f3dd0e10d284c96e79f298308b5"},
 ]
 
 [package.dependencies]
@@ -2695,6 +2948,29 @@ python-versions = "*"
 files = [
     {file = "pytz-2024.1-py2.py3-none-any.whl", hash = "sha256:328171f4e3623139da4983451950b28e95ac706e13f3f2630a879749e7a8b319"},
     {file = "pytz-2024.1.tar.gz", hash = "sha256:2a29735ea9c18baf14b448846bde5a48030ed267578472d8955cd0e7443a9812"},
+]
+
+[[package]]
+name = "pywin32"
+version = "306"
+description = "Python for Window Extensions"
+optional = false
+python-versions = "*"
+files = [
+    {file = "pywin32-306-cp310-cp310-win32.whl", hash = "sha256:06d3420a5155ba65f0b72f2699b5bacf3109f36acbe8923765c22938a69dfc8d"},
+    {file = "pywin32-306-cp310-cp310-win_amd64.whl", hash = "sha256:84f4471dbca1887ea3803d8848a1616429ac94a4a8d05f4bc9c5dcfd42ca99c8"},
+    {file = "pywin32-306-cp311-cp311-win32.whl", hash = "sha256:e65028133d15b64d2ed8f06dd9fbc268352478d4f9289e69c190ecd6818b6407"},
+    {file = "pywin32-306-cp311-cp311-win_amd64.whl", hash = "sha256:a7639f51c184c0272e93f244eb24dafca9b1855707d94c192d4a0b4c01e1100e"},
+    {file = "pywin32-306-cp311-cp311-win_arm64.whl", hash = "sha256:70dba0c913d19f942a2db25217d9a1b726c278f483a919f1abfed79c9cf64d3a"},
+    {file = "pywin32-306-cp312-cp312-win32.whl", hash = "sha256:383229d515657f4e3ed1343da8be101000562bf514591ff383ae940cad65458b"},
+    {file = "pywin32-306-cp312-cp312-win_amd64.whl", hash = "sha256:37257794c1ad39ee9be652da0462dc2e394c8159dfd913a8a4e8eb6fd346da0e"},
+    {file = "pywin32-306-cp312-cp312-win_arm64.whl", hash = "sha256:5821ec52f6d321aa59e2db7e0a35b997de60c201943557d108af9d4ae1ec7040"},
+    {file = "pywin32-306-cp37-cp37m-win32.whl", hash = "sha256:1c73ea9a0d2283d889001998059f5eaaba3b6238f767c9cf2833b13e6a685f65"},
+    {file = "pywin32-306-cp37-cp37m-win_amd64.whl", hash = "sha256:72c5f621542d7bdd4fdb716227be0dd3f8565c11b280be6315b06ace35487d36"},
+    {file = "pywin32-306-cp38-cp38-win32.whl", hash = "sha256:e4c092e2589b5cf0d365849e73e02c391c1349958c5ac3e9d5ccb9a28e017b3a"},
+    {file = "pywin32-306-cp38-cp38-win_amd64.whl", hash = "sha256:e8ac1ae3601bee6ca9f7cb4b5363bf1c0badb935ef243c4733ff9a393b1690c0"},
+    {file = "pywin32-306-cp39-cp39-win32.whl", hash = "sha256:e25fd5b485b55ac9c057f67d94bc203f3f6595078d1fb3b458c9c28b7153a802"},
+    {file = "pywin32-306-cp39-cp39-win_amd64.whl", hash = "sha256:39b61c15272833b5c329a2989999dcae836b1eed650252ab1b7bfbe1d59f30f4"},
 ]
 
 [[package]]
@@ -3012,13 +3288,13 @@ files = [
 
 [[package]]
 name = "sae-lens"
-version = "3.11.0"
+version = "3.12.1"
 description = "Training and Analyzing Sparse Autoencoders (SAEs)"
 optional = false
 python-versions = "<4.0,>=3.10"
 files = [
-    {file = "sae_lens-3.11.0-py3-none-any.whl", hash = "sha256:cb8372b5bb27eeae5047e2786e4a5fcc087dfbd73cd8b43fd4e058ec74b125ea"},
-    {file = "sae_lens-3.11.0.tar.gz", hash = "sha256:3cc8862436a0934b6376ed5bc9e0c9ea4d1b62a7e2d74f80f9c22bb1d714f97d"},
+    {file = "sae_lens-3.12.1-py3-none-any.whl", hash = "sha256:bc3b786ce8b775190d8dad16455eae7d3ba0165812df452ecd38d980637f0e88"},
+    {file = "sae_lens-3.12.1.tar.gz", hash = "sha256:70440eef08753b1c68c3c3e2e929f90bb35c5b1e813e3d9aa5605cb6ec7a025c"},
 ]
 
 [package.dependencies]
@@ -3034,9 +3310,8 @@ pytest-profiling = ">=1.7.0,<2.0.0"
 python-dotenv = ">=1.0.1,<2.0.0"
 pyyaml = ">=6.0.1,<7.0.0"
 pyzmq = "26.0.0"
-sae-vis = ">=0.2.18,<0.3.0"
 safetensors = ">=0.4.2,<0.5.0"
-transformer-lens = ">=1.14.0,<2.0.0"
+transformer-lens = ">=2.0.0,<3.0.0"
 transformers = ">=4.38.1,<5.0.0"
 typer = ">=0.12.3,<0.13.0"
 typing-extensions = ">=4.10.0,<5.0.0"
@@ -3044,28 +3319,6 @@ zstandard = ">=0.22.0,<0.23.0"
 
 [package.extras]
 mamba = ["mamba-lens (>=0.0.4,<0.0.5)"]
-
-[[package]]
-name = "sae-vis"
-version = "0.2.19"
-description = "Open-source SAE visualizer, based on Anthropic's published visualizer."
-optional = false
-python-versions = "<4.0,>=3.10"
-files = [
-    {file = "sae_vis-0.2.19-py3-none-any.whl", hash = "sha256:8e0b4ebd074b76cade3f35dec75b4706d26ec96af6444a3bf5d50cdc1b862e39"},
-    {file = "sae_vis-0.2.19.tar.gz", hash = "sha256:0e42ab61563b70abd76b4c28b38821dedd087e965bdf4104e6ead626eea4ff5c"},
-]
-
-[package.dependencies]
-dataclasses-json = ">=0.6.4,<0.7.0"
-datasets = ">=2.0.0,<3.0.0"
-eindex-callum = ">=0.1.0,<0.2.0"
-einops = ">=0.7.0,<0.8.0"
-jaxtyping = ">=0.2.28,<0.3.0"
-matplotlib = ">=3.8.4,<4.0.0"
-rich = ">=13.7.1,<14.0.0"
-torch = ">=2.0.0,<3.0.0"
-transformer-lens = ">=1.0.0,<2.0.0"
 
 [[package]]
 name = "safetensors"
@@ -3340,13 +3593,13 @@ files = [
 
 [[package]]
 name = "sentry-sdk"
-version = "2.8.0"
+version = "2.9.0"
 description = "Python client for Sentry (https://sentry.io)"
 optional = false
 python-versions = ">=3.6"
 files = [
-    {file = "sentry_sdk-2.8.0-py2.py3-none-any.whl", hash = "sha256:6051562d2cfa8087bb8b4b8b79dc44690f8a054762a29c07e22588b1f619bfb5"},
-    {file = "sentry_sdk-2.8.0.tar.gz", hash = "sha256:aa4314f877d9cd9add5a0c9ba18e3f27f99f7de835ce36bd150e48a41c7c646f"},
+    {file = "sentry_sdk-2.9.0-py2.py3-none-any.whl", hash = "sha256:0bea5fa8b564cc0d09f2e6f55893e8f70286048b0ffb3a341d5b695d1af0e6ee"},
+    {file = "sentry_sdk-2.9.0.tar.gz", hash = "sha256:4c85bad74df9767976afb3eeddc33e0e153300e887d637775a753a35ef99bee6"},
 ]
 
 [package.dependencies]
@@ -3490,13 +3743,13 @@ test = ["pytest"]
 
 [[package]]
 name = "setuptools"
-version = "70.2.0"
+version = "70.3.0"
 description = "Easily download, build, install, upgrade, and uninstall Python packages"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "setuptools-70.2.0-py3-none-any.whl", hash = "sha256:b8b8060bb426838fbe942479c90296ce976249451118ef566a5a0b7d8b78fb05"},
-    {file = "setuptools-70.2.0.tar.gz", hash = "sha256:bd63e505105011b25c3c11f753f7e3b8465ea739efddaccef8f0efac2137bac1"},
+    {file = "setuptools-70.3.0-py3-none-any.whl", hash = "sha256:fe384da74336c398e0d956d1cae0669bc02eed936cdb1d49b57de1990dc11ffc"},
+    {file = "setuptools-70.3.0.tar.gz", hash = "sha256:f171bab1dfbc86b132997f26a119f6056a57950d058587841a0082e8830f9dc5"},
 ]
 
 [package.extras]
@@ -3548,6 +3801,25 @@ files = [
 ]
 
 [[package]]
+name = "stack-data"
+version = "0.6.3"
+description = "Extract data from python stack frames and tracebacks for informative displays"
+optional = false
+python-versions = "*"
+files = [
+    {file = "stack_data-0.6.3-py3-none-any.whl", hash = "sha256:d5558e0c25a4cb0853cddad3d77da9891a08cb85dd9f9f91b9f8cd66e511e695"},
+    {file = "stack_data-0.6.3.tar.gz", hash = "sha256:836a778de4fec4dcd1dcd89ed8abff8a221f58308462e1c4aa2a3cf30148f0b9"},
+]
+
+[package.dependencies]
+asttokens = ">=2.1.0"
+executing = ">=1.2.0"
+pure-eval = "*"
+
+[package.extras]
+tests = ["cython", "littleutils", "pygments", "pytest", "typeguard"]
+
+[[package]]
 name = "statsmodels"
 version = "0.14.2"
 description = "Statistical computations and models for Python"
@@ -3594,17 +3866,20 @@ docs = ["ipykernel", "jupyter-client", "matplotlib", "nbconvert", "nbformat", "n
 
 [[package]]
 name = "sympy"
-version = "1.12.1"
+version = "1.13.0"
 description = "Computer algebra system (CAS) in Python"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "sympy-1.12.1-py3-none-any.whl", hash = "sha256:9b2cbc7f1a640289430e13d2a56f02f867a1da0190f2f99d8968c2f74da0e515"},
-    {file = "sympy-1.12.1.tar.gz", hash = "sha256:2877b03f998cd8c08f07cd0de5b767119cd3ef40d09f41c30d722f6686b0fb88"},
+    {file = "sympy-1.13.0-py3-none-any.whl", hash = "sha256:6b0b32a4673fb91bd3cac3b55406c8e01d53ae22780be467301cc452f6680c92"},
+    {file = "sympy-1.13.0.tar.gz", hash = "sha256:3b6af8f4d008b9a1a6a4268b335b984b23835f26d1d60b0526ebc71d48a25f57"},
 ]
 
 [package.dependencies]
-mpmath = ">=1.1.0,<1.4.0"
+mpmath = ">=1.1.0,<1.4"
+
+[package.extras]
+dev = ["hypothesis (>=6.70.0)", "pytest (>=7.1.0)"]
 
 [[package]]
 name = "tbb"
@@ -3880,6 +4155,26 @@ opt-einsum = ["opt-einsum (>=3.3)"]
 optree = ["optree (>=0.9.1)"]
 
 [[package]]
+name = "tornado"
+version = "6.4.1"
+description = "Tornado is a Python web framework and asynchronous networking library, originally developed at FriendFeed."
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "tornado-6.4.1-cp38-abi3-macosx_10_9_universal2.whl", hash = "sha256:163b0aafc8e23d8cdc3c9dfb24c5368af84a81e3364745ccb4427669bf84aec8"},
+    {file = "tornado-6.4.1-cp38-abi3-macosx_10_9_x86_64.whl", hash = "sha256:6d5ce3437e18a2b66fbadb183c1d3364fb03f2be71299e7d10dbeeb69f4b2a14"},
+    {file = "tornado-6.4.1-cp38-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e2e20b9113cd7293f164dc46fffb13535266e713cdb87bd2d15ddb336e96cfc4"},
+    {file = "tornado-6.4.1-cp38-abi3-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:8ae50a504a740365267b2a8d1a90c9fbc86b780a39170feca9bcc1787ff80842"},
+    {file = "tornado-6.4.1-cp38-abi3-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:613bf4ddf5c7a95509218b149b555621497a6cc0d46ac341b30bd9ec19eac7f3"},
+    {file = "tornado-6.4.1-cp38-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:25486eb223babe3eed4b8aecbac33b37e3dd6d776bc730ca14e1bf93888b979f"},
+    {file = "tornado-6.4.1-cp38-abi3-musllinux_1_2_i686.whl", hash = "sha256:454db8a7ecfcf2ff6042dde58404164d969b6f5d58b926da15e6b23817950fc4"},
+    {file = "tornado-6.4.1-cp38-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:a02a08cc7a9314b006f653ce40483b9b3c12cda222d6a46d4ac63bb6c9057698"},
+    {file = "tornado-6.4.1-cp38-abi3-win32.whl", hash = "sha256:d9a566c40b89757c9aa8e6f032bcdb8ca8795d7c1a9762910c722b1635c9de4d"},
+    {file = "tornado-6.4.1-cp38-abi3-win_amd64.whl", hash = "sha256:b24b8982ed444378d7f21d563f4180a2de31ced9d8d84443907a0a64da2072e7"},
+    {file = "tornado-6.4.1.tar.gz", hash = "sha256:92d3ab53183d8c50f8204a51e6f91d18a15d5ef261e84d452800d4ff6fc504e9"},
+]
+
+[[package]]
 name = "tqdm"
 version = "4.66.4"
 description = "Fast, Extensible Progress Meter"
@@ -3916,13 +4211,13 @@ test = ["argcomplete (>=3.0.3)", "mypy (>=1.7.0)", "pre-commit", "pytest (>=7.0,
 
 [[package]]
 name = "transformer-lens"
-version = "1.19.0"
+version = "2.2.2"
 description = "An implementation of transformers tailored for mechanistic interpretability."
 optional = false
 python-versions = "<4.0,>=3.8"
 files = [
-    {file = "transformer_lens-1.19.0-py3-none-any.whl", hash = "sha256:e9f8f8e804d2cd9099e6e62475f3a781bc9091516c5b2d0305c40df62dd7816c"},
-    {file = "transformer_lens-1.19.0.tar.gz", hash = "sha256:ff9c49fb14f09606131c59e8c9355965fc7c019b6de66518f816fe25f942a4c8"},
+    {file = "transformer_lens-2.2.2-py3-none-any.whl", hash = "sha256:81b091d23b914481dd40a6db05d5adff29202000159bcf1a0db0d68e07e6b1a9"},
+    {file = "transformer_lens-2.2.2.tar.gz", hash = "sha256:08682b80c051807ac10fb7590942a18ec7f9392c8b58c7debeaee3bec5975fbc"},
 ]
 
 [package.dependencies]
@@ -3951,13 +4246,13 @@ wandb = ">=0.13.5"
 
 [[package]]
 name = "transformers"
-version = "4.42.3"
+version = "4.42.4"
 description = "State-of-the-art Machine Learning for JAX, PyTorch and TensorFlow"
 optional = false
 python-versions = ">=3.8.0"
 files = [
-    {file = "transformers-4.42.3-py3-none-any.whl", hash = "sha256:a61a0df9609b7d69229d941b2fd857c841ba3043d6da503d0da1a4b133f65b92"},
-    {file = "transformers-4.42.3.tar.gz", hash = "sha256:7539873ff45809145265cbc94ea4619d2713c41ceaa277b692d8b0be3430f7eb"},
+    {file = "transformers-4.42.4-py3-none-any.whl", hash = "sha256:6d59061392d0f1da312af29c962df9017ff3c0108c681a56d1bc981004d16d24"},
+    {file = "transformers-4.42.4.tar.gz", hash = "sha256:f956e25e24df851f650cb2c158b6f4352dfae9d702f04c113ed24fc36ce7ae2d"},
 ]
 
 [package.dependencies]
@@ -4082,21 +4377,6 @@ files = [
     {file = "typing_extensions-4.12.2-py3-none-any.whl", hash = "sha256:04e5ca0351e0f3f85c6853954072df659d0d13fac324d0072316b67d7794700d"},
     {file = "typing_extensions-4.12.2.tar.gz", hash = "sha256:1a7ead55c7e559dd4dee8856e3a88b41225abfe1ce8df57b7c13915fe121ffb8"},
 ]
-
-[[package]]
-name = "typing-inspect"
-version = "0.9.0"
-description = "Runtime inspection utilities for typing module."
-optional = false
-python-versions = "*"
-files = [
-    {file = "typing_inspect-0.9.0-py3-none-any.whl", hash = "sha256:9ee6fc59062311ef8547596ab6b955e1b8aa46242d854bfc78f4f6b0eff35f9f"},
-    {file = "typing_inspect-0.9.0.tar.gz", hash = "sha256:b23fc42ff6f6ef6954e4852c1fb512cdd18dbea03134f91f856a95ccc9461f78"},
-]
-
-[package.dependencies]
-mypy-extensions = ">=0.3.0"
-typing-extensions = ">=3.7.4"
 
 [[package]]
 name = "tzdata"
@@ -4231,6 +4511,17 @@ models = ["cloudpickle"]
 perf = ["orjson"]
 sweeps = ["sweeps (>=0.2.0)"]
 workspaces = ["wandb-workspaces"]
+
+[[package]]
+name = "wcwidth"
+version = "0.2.13"
+description = "Measures the displayed width of unicode strings in a terminal"
+optional = false
+python-versions = "*"
+files = [
+    {file = "wcwidth-0.2.13-py2.py3-none-any.whl", hash = "sha256:3da69048e4540d84af32131829ff948f1e022c1c6bdb8d6102117aac784f6859"},
+    {file = "wcwidth-0.2.13.tar.gz", hash = "sha256:72ea0c06399eb286d978fdedb6923a9eb47e1c486ce63e9b4e64fc18303972b5"},
+]
 
 [[package]]
 name = "xxhash"
@@ -4516,4 +4807,4 @@ cffi = ["cffi (>=1.11)"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "7951006de1fcfda397822f0a5ee5d93cf4d8db260e4e1fdf5879f72227e3af39"
+content-hash = "7d86d01a82bd4f5da069177a415c44e5ee27b6c9e2849ac8b4e2cbba04c79c8f"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,13 +8,15 @@ readme = "README.md"
 
 [tool.poetry.dependencies]
 python = "^3.10"
-sae-lens = "^3.11.0"
+sae-lens = "^3.12.1"
+transformer-lens = "^2.2.2"
 
 [tool.poetry.group.dev.dependencies]
 ruff = "^0.5.1"
 pytest = "^8.2.2"
 pyright = "^1.1.370"
 pre-commit = "^3.7.1"
+ipykernel = "^6.29.5"
 
 [build-system]
 requires = ["poetry-core"]

--- a/sae_spelling/feature_attribution.py
+++ b/sae_spelling/feature_attribution.py
@@ -1,0 +1,146 @@
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import Any
+
+import torch
+from sae_lens import SAE
+from transformer_lens import HookedTransformer
+
+from sae_spelling.sae_utils import (
+    SaeReconstructionCache,
+    apply_saes_and_run,
+)
+
+EPS = 1e-8
+
+
+@dataclass
+class AttributionGrads:
+    metric: torch.Tensor
+    model_output: torch.Tensor
+    model_activations: dict[str, torch.Tensor]
+    sae_activations: dict[str, SaeReconstructionCache]
+
+
+@dataclass
+class Attribution:
+    model_attributions: dict[str, torch.Tensor]
+    model_activations: dict[str, torch.Tensor]
+    model_grads: dict[str, torch.Tensor]
+    sae_feature_attributions: dict[str, torch.Tensor]
+    sae_feature_activations: dict[str, torch.Tensor]
+    sae_feature_grads: dict[str, torch.Tensor]
+    sae_errors_attribution_proportion: dict[str, float]
+
+
+def calculate_attribution_grads(
+    model: HookedTransformer,
+    prompt: str,
+    metric_fn: Callable[[torch.Tensor], torch.Tensor],
+    track_hook_points: list[str] | None = None,
+    include_saes: dict[str, SAE] | None = None,
+    return_logits: bool = True,
+    include_error_term: bool = True,
+) -> AttributionGrads:
+    """
+    Wrapper around apply_saes_and_run that calculates gradients wrt to the metric_fn.
+    Tracks grads for both SAE feature and model neurons, and returns them in a structured format.
+    """
+    output = apply_saes_and_run(
+        model,
+        saes=include_saes or {},
+        input=prompt,
+        return_type="logits" if return_logits else "loss",
+        track_model_hooks=track_hook_points,
+        include_error_term=include_error_term,
+        track_grads=True,
+    )
+    metric = metric_fn(output.model_output)
+    output.zero_grad()
+    metric.backward()
+    return AttributionGrads(
+        metric=metric,
+        model_output=output.model_output,
+        model_activations=output.model_activations,
+        sae_activations=output.sae_activations,
+    )
+
+
+def calculate_feature_attribution(
+    model: HookedTransformer,
+    input: Any,
+    metric_fn: Callable[[torch.Tensor], torch.Tensor],
+    track_hook_points: list[str] | None = None,
+    include_saes: dict[str, SAE] | None = None,
+    return_logits: bool = True,
+    include_error_term: bool = True,
+) -> Attribution:
+    """
+    Calculate feature attribution for SAE features and model neurons following
+    the procedure in https://transformer-circuits.pub/2024/march-update/index.html#feature-heads.
+    This include the SAE error term by default, so inserting the SAE into the calculation is
+    guaranteed to not affect the model output. This can be disabled by setting `include_error_term=False`.
+
+    Args:
+        model: The model to calculate feature attribution for.
+        input: The input to the model.
+        metric_fn: A function that takes the model output and returns a scalar metric.
+        track_hook_points: A list of model hook points to track activations for, if desired
+        include_saes: A dictionary of SAEs to include in the calculation. The key is the hook point to apply the SAE to.
+        return_logits: Whether to return the model logits or loss. This is passed to TLens, so should match whatever the metric_fn expects (probably logits)
+        include_error_term: Whether to include the SAE error term in the calculation. This is recommended, as it ensures that the SAE will not affecting the model output.
+    """
+    # first, calculate gradients wrt to the metric_fn.
+    # these will be multiplied with the activation values to get the attributions
+    outputs_with_grads = calculate_attribution_grads(
+        model,
+        input,
+        metric_fn,
+        track_hook_points,
+        include_saes=include_saes,
+        return_logits=return_logits,
+        include_error_term=include_error_term,
+    )
+    model_attributions = {}
+    model_activations = {}
+    model_grads = {}
+    sae_feature_attributions = {}
+    sae_feature_activations = {}
+    sae_feature_grads = {}
+    sae_error_proportions = {}
+    # this code is long, but all it's doing is multiplying the grads by the activations
+    # and recording grads, acts, and attributions in dictionaries to return to the user
+    with torch.no_grad():
+        for name, act in outputs_with_grads.model_activations.items():
+            assert act.grad is not None
+            raw_activation = act.detach().clone()
+            model_attributions[name] = (act.grad * raw_activation).detach().clone()
+            model_activations[name] = raw_activation
+            model_grads[name] = act.grad.detach().clone()
+        for name, act in outputs_with_grads.sae_activations.items():
+            assert act.feature_acts.grad is not None
+            assert act.sae_out.grad is not None
+            raw_activation = act.feature_acts.detach().clone()
+            sae_feature_attributions[name] = (
+                (act.feature_acts.grad * raw_activation).detach().clone()
+            )
+            sae_feature_activations[name] = raw_activation
+            sae_feature_grads[name] = act.feature_acts.grad.detach().clone()
+            if include_error_term:
+                assert act.sae_error.grad is not None
+                error_grad_norm = act.sae_error.grad.norm().item()
+            else:
+                error_grad_norm = 0
+            sae_out_norm = act.sae_out.grad.norm().item()
+            sae_error_proportions[name] = error_grad_norm / (
+                sae_out_norm + error_grad_norm + EPS
+            )
+        return Attribution(
+            model_attributions=model_attributions,
+            model_activations=model_activations,
+            model_grads=model_grads,
+            sae_feature_attributions=sae_feature_attributions,
+            sae_feature_activations=sae_feature_activations,
+            sae_feature_grads=sae_feature_grads,
+            sae_errors_attribution_proportion=sae_error_proportions,
+        )

--- a/sae_spelling/sae_utils.py
+++ b/sae_spelling/sae_utils.py
@@ -1,0 +1,123 @@
+from dataclasses import dataclass
+from functools import partial
+from typing import Any, Literal, NamedTuple
+
+import torch
+from sae_lens import SAE
+from transformer_lens import HookedTransformer
+from transformer_lens.hook_points import HookPoint
+
+
+class SaeReconstructionCache(NamedTuple):
+    sae_in: torch.Tensor
+    feature_acts: torch.Tensor
+    sae_out: torch.Tensor
+    sae_error: torch.Tensor
+
+
+def track_grad(tensor: torch.Tensor) -> None:
+    """wrapper around requires_grad and retain_grad"""
+    tensor.requires_grad_(True)
+    tensor.retain_grad()
+
+
+@dataclass
+class ApplySaesAndRunOutput:
+    model_output: torch.Tensor
+    model_activations: dict[str, torch.Tensor]
+    sae_activations: dict[str, SaeReconstructionCache]
+
+    def zero_grad(self) -> None:
+        """Helper to zero grad all tensors in this object."""
+        self.model_output.grad = None
+        for act in self.model_activations.values():
+            act.grad = None
+        for cache in self.sae_activations.values():
+            cache.sae_in.grad = None
+            cache.feature_acts.grad = None
+            cache.sae_out.grad = None
+            cache.sae_error.grad = None
+
+
+def apply_saes_and_run(
+    model: HookedTransformer,
+    saes: dict[str, SAE],
+    input: Any,
+    include_error_term: bool = True,
+    track_model_hooks: list[str] | None = None,
+    return_type: Literal["logits", "loss"] = "logits",
+    track_grads: bool = False,
+) -> ApplySaesAndRunOutput:
+    """
+    Apply the SAEs to the model at the specific hook points, and run the model.
+    By default, this will include a SAE error term which guarantees that the SAE
+    will not affect model output. This function is designed to work correctly with
+    backprop as well, so it can be used for gradient-based feature attribution.
+
+    Args:
+        model: the model to run
+        saes: the SAEs to apply
+        input: the input to the model
+        include_error_term: whether to include the SAE error term to ensure the SAE doesn't affect model output. Default True
+        track_model_hooks: a list of hook points to record the activations and gradients. Default None
+        return_type: this is passed to the model.run_with_hooks function. Default "logits"
+        track_grads: whether to track gradients. Default False
+    """
+
+    fwd_hooks = []
+    bwd_hooks = []
+
+    sae_activations: dict[str, SaeReconstructionCache] = {}
+    model_activations: dict[str, torch.Tensor] = {}
+
+    # this hook just track the SAE input, output, features, and error. If `track_grads=True`, it also ensures
+    # that requires_grad is set to True and retain_grad is called for intermediate values.
+    def reconstruction_hook(sae_in: torch.Tensor, hook: HookPoint, hook_point: str):  # noqa: ARG001
+        sae = saes[hook_point]
+        feature_acts = sae.encode(sae_in)
+        sae_out = sae.decode(feature_acts)
+        sae_error = (sae_in - sae_out).detach().clone()
+        if track_grads:
+            track_grad(sae_error)
+            track_grad(sae_out)
+            track_grad(feature_acts)
+            track_grad(sae_in)
+        sae_activations[hook_point] = SaeReconstructionCache(
+            sae_in=sae_in,
+            feature_acts=feature_acts,
+            sae_out=sae_out,
+            sae_error=sae_error,
+        )
+
+        if include_error_term:
+            return sae_out + sae_error
+        return sae_out
+
+    def sae_bwd_hook(output_grads: torch.Tensor, hook: HookPoint):  # noqa: ARG001
+        # this just passes the output grads to the input, so the SAE gets the same grads despite the error term hackery
+        return (output_grads,)
+
+    # this hook just records model activations, and ensures that intermediate activations have gradient tracking turned on if needed
+    def tracking_hook(hook_input: torch.Tensor, hook: HookPoint, hook_point: str):  # noqa: ARG001
+        model_activations[hook_point] = hook_input
+        if track_grads:
+            track_grad(hook_input)
+        return hook_input
+
+    for hook_point in saes.keys():
+        fwd_hooks.append(
+            (hook_point, partial(reconstruction_hook, hook_point=hook_point))
+        )
+        bwd_hooks.append((hook_point, sae_bwd_hook))
+    for hook_point in track_model_hooks or []:
+        fwd_hooks.append((hook_point, partial(tracking_hook, hook_point=hook_point)))
+
+    # now, just run the model while applying the hooks
+    with model.hooks(fwd_hooks=fwd_hooks, bwd_hooks=bwd_hooks):
+        model_output = model(input, return_type=return_type)
+
+    return ApplySaesAndRunOutput(
+        model_output=model_output,
+        model_activations=model_activations,
+        sae_activations=sae_activations,
+    )

--- a/tests/_comparison/joseph_grad_attrib.py
+++ b/tests/_comparison/joseph_grad_attrib.py
@@ -1,0 +1,121 @@
+import re
+from typing import Callable
+
+import pandas as pd
+import torch
+from sae_lens import SAE
+from transformer_lens import ActivationCache, HookedTransformer
+
+"""
+Copied and modified from Joseph's notebook https://github.com/jbloomAus/SpellingSAEExperiment/blob/main/dev.ipynb
+This is just for use in tests, to assert that our implementation gives identical results
+"""
+
+filter_resid_only = lambda name: "resid" in name
+
+
+def get_cache_fwd_and_bwd(model, tokens, metric, filter=filter_resid_only):
+    model.reset_hooks()
+    cache = {}
+
+    def forward_cache_hook(act, hook):
+        cache[hook.name] = act.detach()
+
+    model.add_hook(filter, forward_cache_hook, "fwd")
+
+    grad_cache = {}
+
+    def backward_cache_hook(act, hook):
+        grad_cache[hook.name] = act.detach()
+
+    model.add_hook(filter, backward_cache_hook, "bwd")
+
+    logits = model(tokens)
+    value = metric(logits)
+    value.backward()
+    model.reset_hooks()
+    return (
+        logits,
+        value.item(),
+        ActivationCache(cache, model),
+        ActivationCache(grad_cache, model),
+    )
+
+
+def get_logit_diff_metric(pos_token: str, neg_token: str, model: HookedTransformer):
+    def logit_diff_metric(logits: torch.Tensor) -> torch.Tensor:
+        positive_token_id = model.to_single_token(pos_token)
+        negative_token_id = model.to_single_token(neg_token)
+        pos_neg_logit_diff = (
+            logits[0, -1, positive_token_id] - logits[0, -1, negative_token_id]  # type: ignore
+        )
+        return pos_neg_logit_diff
+
+    return logit_diff_metric
+
+
+def get_sae_out_all_layers(cache, sae_dict: dict[str, SAE]):
+    sae_outs = {}
+    feature_acts = {}
+    for hook_point, sae in sae_dict.items():
+        sae_feature_acts = sae.encode(cache[hook_point])
+        sae_out = sae.decode(sae_feature_acts)
+        sae_outs[hook_point] = sae_out.float()
+        feature_acts[hook_point] = sae_feature_acts.float()
+
+    return sae_outs, feature_acts
+
+
+def gradient_based_attribution_all_layers(
+    model: HookedTransformer,
+    sparse_autoencoders: dict[str, SAE],
+    prompt: str,
+    metric: Callable[[torch.Tensor], torch.Tensor],
+    position: int = 2,
+):
+    logits, clean_value, clean_cache, clean_grad_cache = get_cache_fwd_and_bwd(
+        model, prompt, metric
+    )
+    sae_outs, feature_acts_dict = get_sae_out_all_layers(
+        clean_cache, sparse_autoencoders
+    )
+
+    attribution_dfs = []
+    for hook_point, sparse_autoencoder in sparse_autoencoders.items():
+        feature_acts = feature_acts_dict[hook_point]
+        fired = (feature_acts[0, position, :] > 0).nonzero().squeeze()
+        activations = feature_acts[0, position, :][fired]
+        fired_directions = sparse_autoencoder.W_dec[fired]
+        contributions = activations[:, None] * fired_directions
+        logit_diff_grad = clean_grad_cache[hook_point][0, position].float()
+        # attribution_scores = contributions @ pos_neg_logit_diff_direction
+        attribution_scores = contributions @ logit_diff_grad
+
+        attribution_df = pd.DataFrame(
+            {
+                "feature": fired.detach().cpu().numpy(),
+                "activation": activations.detach().cpu().numpy(),
+                "attribution": attribution_scores.detach().cpu().numpy(),
+            }
+        )
+        attribution_df["layer"] = sparse_autoencoder.cfg.hook_name
+        attribution_df["layer_idx"] = int(
+            re.search(r"blocks.(\d+).hook_.*", sparse_autoencoder.cfg.hook_name).group(  # type: ignore
+                1
+            )
+        ) + 1 * ("post" in sparse_autoencoder.cfg.hook_name)
+        attribution_df["position"] = position
+
+        attribution_dfs.append(attribution_df)
+
+    attribution_df = pd.concat(attribution_dfs)
+    attribution_df["feature"] = attribution_df.feature.astype(str)
+    attribution_df["layer"] = attribution_df.layer.astype("category")
+
+    tokens = model.to_str_tokens(prompt)
+    unique_tokens = [f"{i}/{tokens[i]}" for i in range(len(tokens))]
+    attribution_df["unique_token"] = attribution_df["position"].apply(
+        lambda x: unique_tokens[x]
+    )
+
+    return attribution_df

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,22 @@
 import pytest
+from sae_lens import SAE
 from transformer_lens import HookedTransformer
 
 
 @pytest.fixture
 def gpt2_model():
     return HookedTransformer.from_pretrained("gpt2", device="cpu")
+
+
+@pytest.fixture
+def gpt2_l4_sae() -> SAE:
+    return SAE.from_pretrained(
+        "gpt2-small-res-jb", "blocks.4.hook_resid_pre", device="cpu"
+    )[0]
+
+
+@pytest.fixture
+def gpt2_l5_sae() -> SAE:
+    return SAE.from_pretrained(
+        "gpt2-small-res-jb", "blocks.5.hook_resid_pre", device="cpu"
+    )[0]

--- a/tests/test_feature_attribution.py
+++ b/tests/test_feature_attribution.py
@@ -1,0 +1,174 @@
+import torch
+from pytest import approx
+from sae_lens import SAE
+from torch import Tensor
+from transformer_lens import HookedTransformer
+
+from sae_spelling.feature_attribution import calculate_feature_attribution
+from tests._comparison.joseph_grad_attrib import gradient_based_attribution_all_layers
+from tests.test_util import set_sae_dtype
+
+
+def test_calculate_feature_attribution_returns_values_that_look_reasonable(
+    gpt2_model: HookedTransformer, gpt2_l4_sae: SAE
+):
+    assert gpt2_model.tokenizer is not None
+    mary_token = gpt2_model.tokenizer.encode(" Mary")[0]
+
+    def metric_fn(logits: Tensor) -> Tensor:
+        return logits[-1, -1, mary_token]
+
+    attrib = calculate_feature_attribution(
+        gpt2_model,
+        "When John and Mary went to the shops, John gave the bag to",
+        metric_fn=metric_fn,
+        track_hook_points=["blocks.3.mlp.hook_post"],
+        include_saes={
+            "blocks.3.hook_resid_pre": gpt2_l4_sae,
+            "blocks.4.hook_resid_pre": gpt2_l4_sae,
+        },
+        include_error_term=True,
+    )
+    assert attrib.model_attributions.keys() == {"blocks.3.mlp.hook_post"}
+    assert attrib.model_activations.keys() == {"blocks.3.mlp.hook_post"}
+    assert attrib.sae_feature_attributions.keys() == {
+        "blocks.3.hook_resid_pre",
+        "blocks.4.hook_resid_pre",
+    }
+    assert attrib.sae_errors_attribution_proportion.keys() == {
+        "blocks.3.hook_resid_pre",
+        "blocks.4.hook_resid_pre",
+    }
+    assert attrib.sae_feature_activations.keys() == {
+        "blocks.3.hook_resid_pre",
+        "blocks.4.hook_resid_pre",
+    }
+    for value in attrib.sae_feature_attributions.values():
+        assert value.shape == (1, 15, 24576)
+        # just to assert that at least some features / gradients are non-zero
+        assert value.abs().sum() > 0.05
+    for value in attrib.sae_feature_activations.values():
+        assert value.shape == (1, 15, 24576)
+        # these should all be positive
+        assert value.sum() > 100
+
+
+def test_calculate_feature_attribution_results_match_josephs_implementation(
+    gpt2_model: HookedTransformer, gpt2_l4_sae: SAE, gpt2_l5_sae: SAE
+):
+    assert gpt2_model.tokenizer is not None
+    mary_token = gpt2_model.tokenizer.encode(" Mary")[0]
+    prompt = "When John and Mary went to the shops, John gave the bag to"
+    saes_dict = {
+        "blocks.4.hook_resid_pre": gpt2_l4_sae,
+        "blocks.5.hook_resid_pre": gpt2_l5_sae,
+    }
+
+    def metric_fn(logits: Tensor) -> Tensor:
+        return logits[-1, -1, mary_token]
+
+    attrib = calculate_feature_attribution(
+        gpt2_model,
+        prompt,
+        metric_fn=metric_fn,
+        include_saes=saes_dict,
+    )
+
+    joseph_attrib = gradient_based_attribution_all_layers(
+        gpt2_model,
+        saes_dict,
+        prompt,
+        metric_fn,
+        position=2,
+    )
+
+    for row in joseph_attrib.itertuples():
+        # pandas doesn't play nicely with type checking
+        hook_point: str = row.layer  # type: ignore
+        feature: int = int(row.feature)  # type: ignore
+        attribution: float = row.attribution  # type: ignore
+        activation: float = row.activation  # type: ignore
+        assert attrib.sae_feature_attributions[hook_point][0, 2, feature] == approx(
+            attribution,
+            abs=1e-5,
+        )
+        assert attrib.sae_feature_activations[hook_point][0, 2, feature] == approx(
+            activation,
+            abs=1e-5,
+        )
+
+
+def test_calculate_feature_attribution_works_with_fp16_models(
+    gpt2_model: HookedTransformer, gpt2_l4_sae: SAE
+):
+    assert gpt2_model.tokenizer is not None
+    mary_token = gpt2_model.tokenizer.encode(" Mary")[0]
+
+    def metric_fn(logits: Tensor) -> Tensor:
+        return logits[-1, -1, mary_token]
+
+    attrib = calculate_feature_attribution(
+        gpt2_model.to(torch.float16),  # type: ignore
+        "When John and Mary went to the shops, John gave the bag to",
+        metric_fn=metric_fn,
+        track_hook_points=["blocks.3.mlp.hook_post"],
+        include_saes={
+            "blocks.3.hook_resid_pre": set_sae_dtype(gpt2_l4_sae, torch.float16),
+            "blocks.4.hook_resid_pre": set_sae_dtype(gpt2_l4_sae, torch.float16),
+        },
+        include_error_term=True,
+    )
+    for value in attrib.sae_feature_attributions.values():
+        assert value.shape == (1, 15, 24576)
+        # just to assert that at least some features / gradients are non-zero
+        assert value.abs().sum() > 0.05
+    for value in attrib.sae_feature_activations.values():
+        assert value.shape == (1, 15, 24576)
+        # these should all be positive
+        assert value.sum() > 100
+
+
+def test_calculate_feature_attribution_returns_identical_model_attribution_with_and_without_saes(
+    gpt2_model: HookedTransformer, gpt2_l4_sae: SAE
+):
+    assert gpt2_model.tokenizer is not None
+    mary_token = gpt2_model.tokenizer.encode(" Mary")[0]
+
+    def metric_fn(logits: Tensor) -> Tensor:
+        return logits[-1, -1, mary_token]
+
+    prompt = "When John and Mary went to the shops, John gave the bag to"
+    track_hook_points = [
+        "blocks.3.mlp.hook_post",
+        "blocks.4.mlp.hook_post",
+        "blocks.5.mlp.hook_post",
+        "blocks.2.attn.hook_z",
+        "blocks.3.attn.hook_z",
+        "blocks.2.hook_attn_in",
+    ]
+
+    without_saes_attrib = calculate_feature_attribution(
+        gpt2_model,
+        prompt,
+        metric_fn=metric_fn,
+        track_hook_points=track_hook_points,
+    )
+
+    with_saes_attrib = calculate_feature_attribution(
+        gpt2_model,
+        prompt,
+        metric_fn=metric_fn,
+        track_hook_points=track_hook_points,
+        include_saes={
+            "blocks.3.hook_resid_pre": gpt2_l4_sae,
+            "blocks.4.hook_resid_pre": gpt2_l4_sae,
+        },
+        include_error_term=True,
+    )
+
+    for with_sae_val, without_sae_val in zip(
+        with_saes_attrib.model_attributions.values(),
+        without_saes_attrib.model_attributions.values(),
+    ):
+        assert torch.allclose(with_sae_val, without_sae_val, atol=1e-5)
+        assert with_sae_val.abs().sum() > 0.05

--- a/tests/test_sae_utils.py
+++ b/tests/test_sae_utils.py
@@ -1,0 +1,73 @@
+import pytest
+import torch
+from sae_lens import SAE
+from transformer_lens import HookedTransformer
+
+from sae_spelling.sae_utils import apply_saes_and_run
+
+
+def test_apply_saes_and_run_returns_identical_output_when_including_sae_error(
+    gpt2_model: HookedTransformer, gpt2_l4_sae: SAE, gpt2_l5_sae: SAE
+):
+    tokens = gpt2_model.to_tokens(["Hello, world!", "Ok then."])
+    original_output, original_cache = gpt2_model.run_with_cache(
+        tokens, names_filter=["blocks.4.mlp.hook_post", "blocks.5.mlp.hook_post"]
+    )
+
+    output = apply_saes_and_run(
+        gpt2_model,
+        {
+            gpt2_l4_sae.cfg.hook_name: gpt2_l4_sae,
+            gpt2_l5_sae.cfg.hook_name: gpt2_l5_sae,
+        },
+        input=tokens,
+        include_error_term=True,
+        track_model_hooks=["blocks.4.mlp.hook_post", "blocks.5.mlp.hook_post"],
+    )
+    with_sae_output = output.model_output
+    with_sae_cache = output.model_activations
+    sae_caches = output.sae_activations
+    assert isinstance(original_output, torch.Tensor)
+    assert torch.allclose(original_output, with_sae_output, atol=1e-4)
+    assert original_cache.keys() == with_sae_cache.keys()
+    for key, value in original_cache.items():
+        assert torch.allclose(value, with_sae_cache[key], atol=1e-4)
+    assert set(sae_caches.keys()) == {
+        gpt2_l4_sae.cfg.hook_name,
+        gpt2_l5_sae.cfg.hook_name,
+    }
+    for sae_cache in sae_caches.values():
+        assert sae_cache.feature_acts.shape == (2, 5, 24576)
+        assert sae_cache.sae_in.shape == (2, 5, 768)
+        assert sae_cache.sae_out.shape == (2, 5, 768)
+        assert sae_cache.sae_error.shape == (2, 5, 768)
+
+
+@pytest.mark.parametrize("include_error_term", [False, True])
+def test_apply_saes_works_with_fp16_models(
+    gpt2_model: HookedTransformer,
+    gpt2_l4_sae: SAE,
+    gpt2_l5_sae: SAE,
+    include_error_term: bool,
+):
+    tokens = gpt2_model.to_tokens(["Hello, world!", "Ok then."])
+    output = apply_saes_and_run(
+        gpt2_model.to(torch.float16),  # type: ignore
+        {
+            gpt2_l4_sae.cfg.hook_name: gpt2_l4_sae,
+            gpt2_l5_sae.cfg.hook_name: gpt2_l5_sae,
+        },
+        input=tokens,
+        include_error_term=include_error_term,
+        track_model_hooks=["blocks.4.mlp.hook_post", "blocks.5.mlp.hook_post"],
+    )
+    sae_caches = output.sae_activations
+    assert set(sae_caches.keys()) == {
+        gpt2_l4_sae.cfg.hook_name,
+        gpt2_l5_sae.cfg.hook_name,
+    }
+    for sae_cache in sae_caches.values():
+        assert sae_cache.feature_acts.shape == (2, 5, 24576)
+        assert sae_cache.sae_in.shape == (2, 5, 768)
+        assert sae_cache.sae_out.shape == (2, 5, 768)
+        assert sae_cache.sae_error.shape == (2, 5, 768)

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -1,6 +1,15 @@
+import torch
+from sae_lens import SAE
+
 from sae_spelling.util import batchify
 
 
 def test_batchify_splits_sequences_into_chunks():
     batches = [batch for batch in batchify(list(range(10)), batch_size=3)]
     assert batches == [[0, 1, 2], [3, 4, 5], [6, 7, 8], [9]]
+
+
+def set_sae_dtype(sae: SAE, dtype: torch.dtype):
+    sae = sae.to(dtype)
+    sae.dtype = dtype
+    return sae


### PR DESCRIPTION
This PR adds a `calculate_feature_attribution()` function which can be used to perform the gradient-based feature attribution from https://transformer-circuits.pub/2024/march-update/index.html#feature-heads, and a `apply_saes_and_run()` function which can run the model while applying SAEs, and return caches of feature activations for both the model and the SAEs.

Feature attribution is demoed in this notebook: https://colab.research.google.com/drive/1--QJ0xxYBygu-Gpf7k6men_zWHxWRa2v

## calculate_feature_attribution()

The function works as below:

```python
    mary_token = model.tokenizer.encode(" Mary")[0]
    john_token = model.tokenizer.encode(" John")[0]
    input = "When John and Mary went to the shops, John gave the bag to"

    def metric_fn(logits: Tensor) -> Tensor:
        return logits[0, -1, mary_token] - logits[0, -1, john_token]

    attrib = calculate_feature_attribution(
        gpt2_model,
        input,
        metric_fn=metric_fn,
        # if desired, specify any hook points in the model to track attributions for as well
        track_hook_points=["blocks.3.mlp.hook_post"],
        include_saes={
            "blocks.4.hook_resid_pre": l4_sae,
            "blocks.5.hook_resid_pre": l5_sae,
        },
    )
```

The returned `Attribution` object has fields related to the activations, gradients, and attribution of the specified SAEs and any model hook points specified in `track_hook_points`. This function can be used with or without SAEs, and with or without tracking model hook points.

The `Attribution` return object has fields like below:

```python
class Attribution:
    model_attributions: dict[str, torch.Tensor]
    model_activations: dict[str, torch.Tensor]
    model_grads: dict[str, torch.Tensor]
    sae_feature_attributions: dict[str, torch.Tensor]
    sae_feature_activations: dict[str, torch.Tensor]
    sae_feature_grads: dict[str, torch.Tensor]
    sae_errors_attribution_proportion: dict[str, float]
```

## apply_saes_and_run()

This PR also includes a function called `apply_saes_and_run()` which can be used to run input through the model while applying SAEs. This function will return an object containing `model_output`, `model_activations`, and `sae_activations`.

Using this function looks like the following:

```python
    output = apply_saes_and_run(
        model,
        saes={ sae.cfg.hook_name: sae },
        input="John and Mary went to the ...",
        # if desired, specify any hook points in the model to record activations for as well
        track_model_hooks=["blocks.4.mlp.hook_post", "blocks.5.mlp.hook_post"],
    )
```

## Including the SAE error term

Both of these functions will include the SAE error term by default when running the SAE. This means that even though the SAE cannot perfectly reconstruct its input, the error term will be added to the SAE output so the model output will be identical with and with the SAE inserted. If this is not desired (e.g. to calculate how model output differs with and without the SAE attached), the error term can be disabled by passing `include_error_term=False`. 

## Other notes
- This PR includes a modified version of Joseph's notebook code in tests to assert that this implementation gives identical results to Joseph's implementation
- This PR required finding and fixing a bug in TransformerLens v2.x.x where backwards hook were not working properly: https://github.com/TransformerLensOrg/TransformerLens/pull/673 

