### PR TITLE
fixing subtle bug with non-english chars that uppercase into English

### DIFF
--- a/sae_spelling/vocab.py
+++ b/sae_spelling/vocab.py
@@ -6,6 +6,7 @@ from transformers import PreTrainedTokenizerFast
 
 LETTERS = "abcdefghijklmnopqrstuvwxyz"
 LETTERS_UPPER = LETTERS.upper()
+ALL_ALPHA_LETTERS = LETTERS + LETTERS_UPPER
 
 
 def get_tokens(
@@ -31,7 +32,7 @@ def get_alpha_tokens(
             token = token[1:]
         if len(token) == 0:
             return False
-        return all(char.upper() in LETTERS_UPPER for char in token)
+        return all(char in ALL_ALPHA_LETTERS for char in token)
 
     return get_tokens(
         tokenizer, filter_alpha, replace_special_chars=replace_special_chars

--- a/tests/test_vocab.py
+++ b/tests/test_vocab.py
@@ -1,6 +1,7 @@
 from transformers import GPT2TokenizerFast
 
 from sae_spelling.vocab import (
+    LETTERS,
     LETTERS_UPPER,
     get_alpha_tokens,
     get_nltk_words,
@@ -9,7 +10,7 @@ from sae_spelling.vocab import (
 
 
 def is_alpha(word: str) -> bool:
-    return all(char.upper() in LETTERS_UPPER for char in word)
+    return all(char in LETTERS or char in LETTERS_UPPER for char in word)
 
 
 def test_get_tokens_returns_all_tokens_by_default(


### PR DESCRIPTION
`get_alpha_tokens()` previously checked if a character was alpha by checking if `char.upper() in LETTERS_UPPER`. However, this had a subtle bug, where some weird non-English chars uppercase into English. For instance, `"ſ".upper() == "S"`.

This PR fixes the issue by explicitly checking if the char is in the exact list of lower and upper case letters without calling `.lower()` or `.upper()` anywhere.