### PR TITLE
improving performance of create-icl-prompt

### DIFF
--- a/sae_spelling/prompting.py
+++ b/sae_spelling/prompting.py
@@ -123,7 +123,7 @@ def create_icl_prompt(
         shuffle_examples: whether to shuffle the examples before selecting the first `max_icl_examples`. default is True
     """
     icl_prompts = []
-    icl_examples = examples.copy()
+    icl_examples = examples
 
     if max_icl_examples is not None:
         if shuffle_examples:
@@ -131,6 +131,7 @@ def create_icl_prompt(
         else:
             icl_examples = icl_examples[:max_icl_examples]
     elif shuffle_examples:
+        icl_examples = examples.copy()
         random.shuffle(icl_examples)
     for ex in icl_examples:
         ex_answer = answer_formatter(ex)

--- a/tests/test_prompting.py
+++ b/tests/test_prompting.py
@@ -1,11 +1,14 @@
 from textwrap import dedent
 
+from transformers import GPT2TokenizerFast
+
 from sae_spelling.prompting import (
     create_icl_prompt,
     first_letter,
     first_letter_formatter,
     spelling,
 )
+from sae_spelling.vocab import get_alpha_tokens
 
 
 def test_spelling_uses_dash_as_default_separator():
@@ -101,3 +104,14 @@ def test_create_icl_prompt_can_specify_max_icl_examples():
     assert prompt.base == dedent(expected_base).strip()
     assert prompt.word == "cat"
     assert prompt.answer == " c-a-t"
+
+
+def test_create_icl_prompt_peformance_is_fast(gpt2_tokenizer: GPT2TokenizerFast):
+    "Just run create_icl_prompt lots of times to make sure it's reasonably fast"
+    vocab = get_alpha_tokens(gpt2_tokenizer)
+    for _ in range(10):
+        prompts = [
+            create_icl_prompt(word, examples=vocab, max_icl_examples=10)
+            for word in vocab
+        ]
+        assert len(prompts) == len(vocab)


### PR DESCRIPTION
This PR improves performance of the `create_icl_prompt()` helper by not first copying the vocab at the start of the function. This now only happens if we actually want to use the entire vocab as a single ICL prompt, which in practice won't be done except with very small vocab sizes.