### PR TITLE
allow not shuffling for spelling grader ICL examples

### DIFF
--- a/sae_spelling/spelling_grader.py
+++ b/sae_spelling/spelling_grader.py
@@ -32,6 +32,7 @@ class SpellingGrader:
     base_template: str = "{word}:"
     answer_formatter: Formatter = spelling_formatter()
     example_separator: str = "\n"
+    shuffle_examples: bool = True
 
     def grade_word(self, word: str) -> SpellingGrade:
         return self.grade_words([word])[0]
@@ -47,6 +48,7 @@ class SpellingGrader:
                 answer_formatter=self.answer_formatter,
                 example_separator=self.example_separator,
                 max_icl_examples=self.max_icl_examples,
+                shuffle_examples=self.shuffle_examples,
             )
             for word in words
         ]

--- a/tests/test_spelling_grader.py
+++ b/tests/test_spelling_grader.py
@@ -26,7 +26,7 @@ def test_spelling_grader_marks_response_correct_if_model_predicts_correctly(
     assert grade.prompt == create_icl_prompt("correct", examples=icl_words).base
 
 
-def test_spelling_grader_allows_setting_an_answer_formater(
+def test_spelling_grader_allows_setting_an_answer_formatter(
     gpt2_model: HookedTransformer,
 ):
     # GPT2 should be able to spell the word correctly after seeing 4 ICL examples of it spelled correctly
@@ -40,6 +40,22 @@ def test_spelling_grader_allows_setting_an_answer_formater(
     assert grade.answer == " C"
     assert grade.prediction == " C"
     assert grade.answer_log_prob == grade.prediction_log_prob
+
+
+def test_spelling_grader_allows_not_shuffling_examples(
+    gpt2_model: HookedTransformer,
+):
+    # GPT2 should be able to spell the word correctly after seeing 4 ICL examples of it spelled correctly
+    grader = SpellingGrader(
+        gpt2_model,
+        icl_word_list=["one", "two", "three", "four", "five"],
+        shuffle_examples=False,
+    )
+    grade = grader.grade_word("correct")
+    assert grade.prompt.index("one") < grade.prompt.index("two")
+    assert grade.prompt.index("two") < grade.prompt.index("three")
+    assert grade.prompt.index("three") < grade.prompt.index("four")
+    assert grade.prompt.index("four") < grade.prompt.index("five")
 
 
 def test_spelling_grader_marks_response_wrong_if_model_predicts_incorrectly(


### PR DESCRIPTION
This PR adds an option, `shuffle_examples`, to the spelling grader which allows us to turn off example shuffling